### PR TITLE
link to HTTP::Throwable

### DIFF
--- a/lib/HTTP/Exception.pm
+++ b/lib/HTTP/Exception.pm
@@ -297,6 +297,8 @@ capable of.
 
 Constants, Statuscodes and Statusmessages
 
+=head2 L<HTTP::Throwable>, built on top of the more modern L<Throwable> framework (the successor to L<Exception::Class>)
+
 =head2 L<Plack>, especially L<Plack::Middleware::HTTPExceptions>
 
 Have a look at Plack, because it rules in general. In the first place, this


### PR DESCRIPTION
Exception::Class is deprecated and explictly recommends migration to Throwable - HTTP::Throwable is just like HTTP::Exception only built atop of Throwable rather than Exception::Class.
